### PR TITLE
适配 gradle configuration cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 local.properties
 build/
 .idea
+# 所有包含 bin 文件夹的目录，Cursor 会生成很多 bin 文件夹，这里排除掉
+**/bin/

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,11 @@ kotlin.code.style=official
 android.nonTransitiveRClass=false
 android.defaults.buildfeatures.viewbinding = true
 
+# Enable configuration cache
+org.gradle.unsafe.configuration-cache=true
+
+# Use this flag sparingly, in case some of the plugins are not fully compatible
+org.gradle.unsafe.configuration-cache-problems=warn
 
 PROJ_GROUP=io.github.FlyJingFish.ModuleCommunication
 PROJ_BASENAME=ModuleCommunication

--- a/module-communication-plugin/src/main/kotlin/com/flyjingfish/module_communication_plugin/ApplyExportPlugin.kt
+++ b/module-communication-plugin/src/main/kotlin/com/flyjingfish/module_communication_plugin/ApplyExportPlugin.kt
@@ -64,28 +64,28 @@ class ApplyExportPlugin: Plugin<Project> {
                 val variantName = variant.name
                 val variantNameCapitalized = variantName.capitalized()
                 project.tasks.register("generateCommunicationCode$variantNameCapitalized", ExportTask::class.java) {
-                    it.variant = variant
+                    it.variantName = variant.name
                     it.communicationConfig = communicationConfig
                     it.exportModuleName = moduleName
                     it.copyType = ExportTask.CopyType.COPY_CODE
                 }.dependsOn("ksp${variantNameCapitalized}Kotlin")
 
                 project.tasks.register("generateCommunicationRes$variantNameCapitalized", ExportTask::class.java) {
-                    it.variant = variant
+                    it.variantName = variant.name
                     it.communicationConfig = communicationConfig
                     it.exportModuleName = moduleName
                     it.copyType = ExportTask.CopyType.COPY_RES
                 }
 
                 project.tasks.register("generateCommunicationAssets$variantNameCapitalized", ExportTask::class.java) {
-                    it.variant = variant
+                    it.variantName = variant.name
                     it.communicationConfig = communicationConfig
                     it.exportModuleName = moduleName
                     it.copyType = ExportTask.CopyType.COPY_ASSETS
                 }
 
                 project.tasks.register("generateCommunicationAll$variantNameCapitalized", ExportTask::class.java) {
-                    it.variant = variant
+                    it.variantName = variant.name
                     it.communicationConfig = communicationConfig
                     it.exportModuleName = moduleName
                     it.copyType = ExportTask.CopyType.ALL

--- a/module-communication-plugin/src/main/kotlin/com/flyjingfish/module_communication_plugin/ExportTask.kt
+++ b/module-communication-plugin/src/main/kotlin/com/flyjingfish/module_communication_plugin/ExportTask.kt
@@ -1,6 +1,5 @@
 package com.flyjingfish.module_communication_plugin
 
-import com.android.build.api.variant.Variant
 import com.android.build.gradle.LibraryExtension
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -18,7 +17,7 @@ abstract class ExportTask : DefaultTask() {
     }
 
     @get:Input
-    abstract var variant: Variant
+    abstract var variantName: String
     @get:Input
     abstract var communicationConfig: CommunicationConfig
     @get:Input
@@ -32,7 +31,7 @@ abstract class ExportTask : DefaultTask() {
 
     @TaskAction
     fun taskAction() {
-        TmpUtils.initTmp(project.project(":${exportModuleName}".replace("\"","")),variant)
+        TmpUtils.initTmp(project.project(":${exportModuleName}".replace("\"","")),variantName)
         when(copyType){
             CopyType.COPY_RES ->{
                 searchResFileAndCopy(project)
@@ -53,7 +52,7 @@ abstract class ExportTask : DefaultTask() {
     }
 
     private fun searchAssetsFileAndCopy(curProject: Project){
-        val codePath = "/${LibVersion.buildDir}/${variant.name}/${LibVersion.assetsName}".replace('/', File.separatorChar)
+        val codePath = "/${LibVersion.buildDir}/${variantName}/${LibVersion.assetsName}".replace('/', File.separatorChar)
         val libraryExtension = project.extensions.getByName("android") as LibraryExtension
         val variantNames = libraryExtension.sourceSets.names
 
@@ -109,7 +108,7 @@ abstract class ExportTask : DefaultTask() {
     }
 
     private fun searchResFileAndCopy(curProject: Project){
-        val codePath = "/${LibVersion.buildDir}/${variant.name}/${LibVersion.resName}".replace('/',File.separatorChar)
+        val codePath = "/${LibVersion.buildDir}/${variantName}/${LibVersion.resName}".replace('/',File.separatorChar)
         val libraryExtension = project.extensions.getByName("android") as LibraryExtension
         val variantNames = libraryExtension.sourceSets.names
 
@@ -198,8 +197,7 @@ abstract class ExportTask : DefaultTask() {
     }
 
     private fun searchApiFileAndCopy(curProject: Project){
-        val variantName = variant.name
-        val codePath = "/${LibVersion.buildDir}/${variant.name}/${LibVersion.pathName}".replace('/',File.separatorChar)
+        val codePath = "/${LibVersion.buildDir}/${variantName}/${LibVersion.pathName}".replace('/',File.separatorChar)
         val genFile = curProject.file("${curProject.buildDir}${File.separator}generated${File.separator}ksp${File.separator}${variantName}").listFiles()
         val collection = curProject.files(genFile).asFileTree.filter { it.name.endsWith(".api") }
 

--- a/module-communication-plugin/src/main/kotlin/com/flyjingfish/module_communication_plugin/TmpUtils.kt
+++ b/module-communication-plugin/src/main/kotlin/com/flyjingfish/module_communication_plugin/TmpUtils.kt
@@ -1,6 +1,5 @@
 package com.flyjingfish.module_communication_plugin
 
-import com.android.build.api.variant.Variant
 import com.android.build.gradle.internal.coverage.JacocoReportTask
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -54,9 +53,9 @@ object TmpUtils {
     }
 
 
-    fun initTmp(project: Project, variant: Variant){
+    fun initTmp(project: Project, variantName: String){
         val dir = project.projectDir
-        val codePath = "build/${LibVersion.buildDir}/${variant.name}".replace("/", File.separator)
+        val codePath = "build/${LibVersion.buildDir}/${variantName}".replace("/", File.separator)
         val buildFile = File(dir, codePath)
         buildConfigCacheFile = File(buildFile.absolutePath, "tmp.json")
         if (temporaryDirMkdirs()){

--- a/module-communication-plugin/src/main/kotlin/com/flyjingfish/module_communication_plugin/TmpUtils.kt
+++ b/module-communication-plugin/src/main/kotlin/com/flyjingfish/module_communication_plugin/TmpUtils.kt
@@ -53,10 +53,9 @@ object TmpUtils {
     }
 
 
-    fun initTmp(project: Project, variantName: String){
-        val dir = project.projectDir
+    fun initTmp(projectDir: File, variantName: String){
         val codePath = "build/${LibVersion.buildDir}/${variantName}".replace("/", File.separator)
-        val buildFile = File(dir, codePath)
+        val buildFile = File(projectDir, codePath)
         buildConfigCacheFile = File(buildFile.absolutePath, "tmp.json")
         if (temporaryDirMkdirs()){
             val bean :IncrementalRecord? = optFromJsonString(readAsString(buildConfigCacheFile.absolutePath),IncrementalRecord::class.java)


### PR DESCRIPTION
ApplyExportPlugin、ExportTask、TmpUtils 改成使用 variant.name 替换 Variant，从而适配 gradle configuration cache